### PR TITLE
Updated pegs_convert_type() in PEGS_common.R

### DIFF
--- a/pegs_common_utils.R
+++ b/pegs_common_utils.R
@@ -261,41 +261,41 @@ prepare_pegs_phenotype <- function(pegs_data, phenotype) {
 
 #' PEGS data converter
 #'
-#' convert PEGS text table entries to NA and proper R types;
+#' Convert columns  in the  PEGS data  frame to  appropriate variable  types as
+#' specified in the metadata file.  Special codes are converted to NA.
 #'
-#' this function works for text tables and meta-data from PEGS Freeze v2,
-#' loaded from
-#'
-#' - /ddn/gs1/project/controlled/PEGS/Data_Freezes/freeze_v2/Surveys
-#'   * Health_and_Exposure/healthexposure_*_v2.* # epr.he and epr.he.meta
-#'   * Exposome/exposomea_*_v2.*                 # exposome a
-#'   * Exposome/exposomea_*_v2.*                 # exposome b
-#'
-#' @param dat one of the PEGS text tables (i.e., epr.he)
-#' @param met corresponding meta-data (i.e., epr.he.meta)
-#' @return data frame with NA and proper column classes.
-cvt <- function(dat, met, quiet=TRUE)
+#' @param pegs_df The PEGS dataframe to convert
+#' @param pegs_df_meta The accompanying PEGS metadata dataframe
+#' @param quiet do not report conversion progress (def=TRUE)
+#' @return The converted PEGS dataframe
+cvt <- function(pegs_df, pegs_df_meta, quiet=TRUE)
 {
-    ## code for NA
-    NAS <- c(".M", ".S", ".N", "-444444", "-555555", "-666666", "-777777", "-888888", "-999999")
+    ## special code for NA
+    PEGS_SP_CODES <- c(".M", ".S", ".N", "-444444", "-555555", "-666666",
+                       "-777777", "-888888", "-999999")
     ## list for converters, add character="identity"
-    CVS <- c(binary=as.factor, factor=as.factor, numeric=as.numeric,
-             `ordered factor`=as.factor, date=as.Date, character=identity)
+    CONVERTERS <- c(binary=as.factor, factor=as.factor, numeric=as.numeric,
+                    `ordered factor`=as.factor, date=as.Date, character=identity)
 
     ## set NA
-    dat <- as.matrix(dat); dat[dat %in% NAS] <- NA; dat <- as.data.frame(dat)
+    pegs_df <- as.matrix(pegs_df)
+    pegs_df[pegs_df %in% PEGS_SP_CODES] <- NA
+    pegs_df <- as.data.frame(pegs_df)
     
     ## convert to R types
-    ## look up the meta-data with table headers, gets long variable names
-    ## look up the list of converter with long variable names, gets converters
-    cnv <- CVS[met$true_class[match(names(dat), met$long_variable_name)]]
-    for(i in seq_along(dat))
+    ## look up the meta-data long variable names with table headers, gets true class
+    true_class <- with(pegs_df_meta,
+                       true_class[match(names(pegs_df), long_variable_name)])
+    ## look up the list of converter with true classes, gets converters
+    converters <- CONVERTERS[true_class]
+    for(i in seq_along(pegs_df))
     {
-        dat[[i]] <- cnv[[i]](dat[[i]])
+        pegs_df[[i]] <- converters[[i]](pegs_df[[i]])
         if(!quiet)
-            cat(sprintf("%4i %-40s %16s -> %s\n", i, names(dat)[i], lvn[i], class(dat[[i]])))
+            cat(sprintf("%4i %-40s %16s -> %s\n",
+                        i, names(pegs_df)[i], true_class[i], class(pegs_df[[i]])))
     }
-    dat
+    return(pegs_df)
 }
 
 #' check the equivalence between coverters
@@ -308,19 +308,19 @@ test <- function()
     ## test health and exposure
     load(file.path(pgs_dir, "Surveys/Health_and_Exposure/healthexposure_26aug21_v2.RData"))
     he1 <- pegs_convert_type(epr.he, epr.he.meta)
-    he2 <- cvt(epr.he, epr.he.meta)
+    he2 <- cvt(epr.he, epr.he.meta, quiet=FALSE)
     cat("he1 == he2: ", all.equal(as.data.frame(he1), he2), "\n", sep="")
 
     ## test exposome A
     load(file.path(pgs_dir, "Surveys/Exposome/exposomea_02jun21_v2.RData"))
     ea1 <- pegs_convert_type(epr.ea, epr.ea.meta)
-    ea2 <- cvt(epr.ea, epr.ea.meta)
+    ea2 <- cvt(epr.ea, epr.ea.meta, quiet=FALSE)
     cat("ea1 == ea2: ", all.equal(as.data.frame(ea1), ea2), "\n", sep="")
     
     ## test exposome B
     load(file.path(pgs_dir, "Surveys/Exposome/exposomeb_02jun21_v2.RData"))
     eb1 <- pegs_convert_type(epr.eb, epr.eb.meta)
-    eb2 <- cvt(epr.eb, epr.eb.meta)
+    eb2 <- cvt(epr.eb, epr.eb.meta, quiet=FALSE)
     cat("eb1 == eb2: ", all.equal(as.data.frame(eb1), eb2), "\n", sep="")
 
     invisible(NULL)


### PR DESCRIPTION
Replaced c with new version.
* The NA special codes *PEGS_SP_CODES* remained as they were, as a global variable.
* The new *pegs_convert_type()* follows all required naming and syntax convention in the review.
* the old *pegs_convert_type()* renames to pegs_convert_type_original()
  - keep the older function for a while longer
  - others may want to verity the equivalence of the two in their pipelines. 
* the equivalence test function renames to *pegs_convert_type_test()*
   - All tests returned "TRUE", therefore, the new and old pegs_convert_type() are equivalent.

Please merge these changes with the master branch.
